### PR TITLE
Fix tiny-keccak in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ thiserror = "1.0"
 
 k256 = "0.13"
 keccak-asm = { version = "0.1.0", default-features = false }
-tiny-keccak = { git = "https://github.com/succinctlabs/tiny-keccak-private.git", branch = "chris/test" }
+tiny-keccak = { git = "https://github.com/succinctlabs/tiny-keccak-private.git", branch = "chris/test", features = ["keccak"] }
 
 # misc
 alloy-rlp = { version = "0.3", default-features = false }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`tiny-keccak` in `Cargo.toml` requires enabling at least one feature flag to compile, but none is included.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add ["keccak"] to the features of `tiny-keccak`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
